### PR TITLE
#36 docker exec now refer to $HOST insted image name

### DIFF
--- a/yaim/run_lwce.sh
+++ b/yaim/run_lwce.sh
@@ -77,4 +77,4 @@ echo "The following docker command will be executed:"
 echo $DOCKER_RUN
 
 $DOCKER_RUN
-sudo docker exec -it lwce-umd4 /ce-config/init.sh
+sudo docker exec -it $HOST /ce-config/init.sh


### PR DESCRIPTION
Fixed docker exec call to init.sh.

Now he references to the $HOST instead image name